### PR TITLE
Disable CHECK_INTERVAL when using journalctl

### DIFF
--- a/psad
+++ b/psad
@@ -818,14 +818,12 @@ MAIN: for (;;) {
 
         ### Get any new packets have been written to syslog
         if ($config{'ENABLE_FW_MSG_READ_CMD'} eq 'Y') {
-            if ($s->can_read(.5)) {
-                my $syslog_line = <$fwdata_fh>;
-                $fwdata_fh->flush();
-                push @fw_packets, $syslog_line unless $fw_msg_read_continue;
-                $fw_msg_read_do_sleep = 0;
-            } else {
+            if ($s->can_read(120)) {
+                while ($s->can_read(.5) && @fw_packets < 10) {
+                    my $syslog_line = <$fwdata_fh>;
+                    push @fw_packets, $syslog_line unless $fw_msg_read_continue;
+                }
                 $fw_msg_read_continue = 0;
-                $fw_msg_read_do_sleep = 1;
             }
 
         } else {
@@ -848,18 +846,14 @@ MAIN: for (;;) {
     ### sleep for the check interval seconds
     if ($config{'ENABLE_FW_MSG_READ_CMD'} eq 'Y') {
 
-        if ($fw_msg_read_do_sleep
-                or (($#fw_packets+1) % $config{'FW_MSG_READ_MIN_PKTS'} == 0)) {
-
-            if (@fw_packets) {
-                ### Extract data and summarize scan packets, assign danger
-                ### level, send email/syslog alerts.
-                &check_scan(\@fw_packets);
-            }
-
-            &post_scan_processing($#fw_packets+1, \@add_ipt_addrs);
-            @fw_packets = ();
+        if (@fw_packets) {
+            ### Extract data and summarize scan packets, assign danger
+            ### level, send email/syslog alerts.
+            &check_scan( \@fw_packets );
         }
+
+        &post_scan_processing( $#fw_packets + 1, \@add_ipt_addrs );
+        @fw_packets = ();
 
         unless (&look_for_process(quotemeta($fw_read_cmd))) {
             &sys_log("firewall logs read command '$fw_read_cmd' " .
@@ -871,7 +865,6 @@ MAIN: for (;;) {
             $fw_msg_read_continue = 1;
         }
 
-        sleep $config{'CHECK_INTERVAL'} if $fw_msg_read_do_sleep;
 
     } else {
 


### PR DESCRIPTION
If we are getting all our data from journalctl, I don't see a point in using the old polling method. This is an attempt to allow psad to wait for IO activity instead of waiting for a timeout. 

I am using this for my personal servers with no ill effects. I am not asking you to accept this pull request but I do ask that you consider the idea.

Since `can_read()` blocks by default, I removed the timeout to allow psad to wait until it receives activity from the child process watching journalctrl (well actually I gave it a timeout of 120 since I guess we would not want it to accidentally block forever if the background process got killed). Once activity is detected we enter a second state defined by the `while` loop that calls `can_read()` with a short timeout. This is due to the fact that since we are reading from a pipe, we will never get an EOF and thus a normal read would block forever. Once the second read times out, the process then flows though the normal process (minus the last `sleep $config{'CHECK_INTERVAL'}`). 

I did add a hard limit of `@fw_packets < 10` since on a busy host this read would never time out, though perhaps we could set it to `$config{'FW_MSG_READ_MIN_PKTS'}`