### PR TITLE
Bugfix: String pointer not dereferenced.

### DIFF
--- a/psadwatchd.c
+++ b/psadwatchd.c
@@ -389,8 +389,8 @@ static void exec_binary(const char *binary, const char *cmdlinefile)
 
         while (*index != '\n' && *index != '\0') {
             non_ws = 0;
-            while (*index != ' ' && *index != '\t'
-                    && index != '\0' && *index != '\n') {
+            while (*index != ' '  && *index != '\t'
+                && *index != '\0' && *index != '\n') {
                 index++;
                 non_ws++;
             }


### PR DESCRIPTION
Closes: https://github.com/mrash/psad/issues/56

While compiling psad for Ubuntu, I noticed the following warning:
```
psadwatchd.c: In function ‘exec_binary’:
psadwatchd.c:393:30: warning: comparison between pointer and zero character constant [-Wpointer-compare]
                     && index != '\0' && *index != '\n') {
                              ^~
psadwatchd.c:393:24: note: did you mean to dereference the pointer?
                     && index != '\0' && *index != '\n') {
                        ^
```
From inspection of the code, it would appear that `index` should be `*index` in the above code.

This patch fixes the problem, and also adjusts alignment to clarify the intent.