### PR TITLE
add external unblock script support

### DIFF
--- a/psad
+++ b/psad
@@ -7208,7 +7208,10 @@ sub ipt_rm_block() {
         }
         print STDERR "[+] ipt_rm_block(): removed iptables block ",
             "against $ip\n" if $debug;
-
+            
+        if ($config{'ENABLE_EXT_UNBLOCK_SCRIPT_EXEC'} eq 'Y') {
+            &exec_external_script($ip, $config{'EXTERNAL_UNBLOCK_SCRIPT'});
+        }
         return 1;
     }
 


### PR DESCRIPTION
Using the block script it's possible to maintain an ipset, however auto-unblocked IPs will not be removed from the ipset. This commit makes it possible to define an unblock script for such purposes.